### PR TITLE
Fix wscdn push crash

### DIFF
--- a/rtmp/RTMPSession.cpp
+++ b/rtmp/RTMPSession.cpp
@@ -948,6 +948,11 @@ namespace videocore
                 p += amfPrimitiveObjectSize(p);
                 props[propName] = "";
             }
+            // Fix large AMF object may break to multiple packets
+            // that crash us.
+            if (strcmp(propName, "code") == 0) {
+                break;
+            }
         } while (get_be24(p) != AMF_DATA_TYPE_OBJECT_END);
         
         //p = start;


### PR DESCRIPTION
RTMP block if large as 128 bytes, it should break to two blocks. Our
parse is too navie to handle this and will crash.

That’s happen on ChinanetCenter’s RTMP CDN system.
